### PR TITLE
modify the clean job

### DIFF
--- a/openfunction/templates/hook/job.yaml
+++ b/openfunction/templates/hook/job.yaml
@@ -7,19 +7,19 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-failed,hook-succeeded
 spec:
   template:
     spec:
       containers:
-      - name: hyperkube
-        image: openfunction/hyperkube:v1.18.0
+      - name: kubectl
+        image: bitnami/kubectl:1.22
         command:
         - kubectl
         - delete
         - gateway
         - openfunction
-        - {{ .Release.Namespace }}
+        - --ignore-not-found=true
       restartPolicy: Never
       serviceAccountName: {{ include "openfunction.fullname" . }}-controller-manager
 ---
@@ -31,19 +31,20 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-failed,hook-succeeded
 spec:
   template:
     spec:
       containers:
-      - name: hyperkube
-        image: openfunction/hyperkube:v1.18.0
+      - name: kubectl
+        image: bitnami/kubectl:1.22
         command:
         - kubectl
         - delete
         - ns
         - {{ .Values.contour.namespaceOverride }}
         - --wait=false
+        - --ignore-not-found=true
       restartPolicy: Never
       serviceAccountName: ns-edit
 {{- end }}


### PR DESCRIPTION
The image size of `hyperkube` is too big, replace it with `kubectl`.
Signed-off-by: wrongerror <wangyifei@kubesphere.io>