### PR TITLE
feat: upgrade k8s gateway version from v1alpha2 to v1beta1

### DIFF
--- a/openfunction/templates/gateway/gateway-class.yaml
+++ b/openfunction/templates/gateway/gateway-class.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.Contour.enabled }}
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   name: contour

--- a/openfunction/templates/gateway/gateway.yaml
+++ b/openfunction/templates/gateway/gateway.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.Contour.enabled }}
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: contour


### PR DESCRIPTION
closes #62 

After reviewing the CRDs, I think we can also upgrade https://github.com/OpenFunction/charts/blob/main/openfunction/crds/gateway-api.yaml to include v1. That could be in another PR though.
